### PR TITLE
Apple Liquid Glass redesign with amber brand tint

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "crack-crime-next",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "crack-crime-next",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     }
   ]
 }

--- a/src/app/admin/missing/page.tsx
+++ b/src/app/admin/missing/page.tsx
@@ -105,7 +105,7 @@ const Page = () => {
 
   return (
     <main className="font-nunito py-3 m-2 rounded-3xl">
-      <h1 className="text-2xl font-bold rounded-3xl border-2 border-black py-2 text-center">Missing Persons</h1>
+      <h1 className="text-2xl font-bold rounded-3xl border border-amber-300/30 bg-amber-400/10 backdrop-blur-sm py-2 text-center text-amber-50">Missing Persons</h1>
       <div className="flex p-2 mb-4 justify-around">
         <Button
           className="font-bold text-lg"
@@ -146,27 +146,27 @@ const Page = () => {
         <div className="w-full">
           {loading ? (
             <div className="flex justify-center py-8">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900"></div>
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-400"></div>
             </div>
           ) : error ? (
-            <div className="text-red-600 text-center py-4">
+            <div className="text-red-300 text-center py-4">
               Error: {error}
-              <button 
+              <button
                 onClick={fetchMissingPersons}
-                className="block mx-auto mt-2 bg-blue-500 text-white px-4 py-2 rounded"
+                className="block mx-auto mt-2 bg-amber-400/20 backdrop-blur-sm border border-amber-300/30 text-amber-50 px-4 py-2 rounded-xl hover:bg-amber-400/30 transition-all duration-200"
               >
                 Retry
               </button>
             </div>
           ) : missings.length === 0 ? (
-            <div className="text-center py-8 text-gray-500">
+            <div className="text-center py-8 text-amber-300/60">
               No missing persons reported
             </div>
           ) : (
             missings.map((missing) => (
               <div
                 key={missing.id}
-                className="bg-white text-black rounded-3xl py-2 px-4 my-2"
+                className="bg-amber-400/10 backdrop-blur-md border border-amber-300/20 text-amber-50 rounded-3xl py-2 px-4 my-2 shadow-[0_4px_16px_rgba(217,119,6,0.1)]"
               >
                 <MissingListItem 
                   name={missing.name}
@@ -177,13 +177,13 @@ const Page = () => {
                   image={missing.image}
                 />
                 {missing.description && (
-                  <div className="mt-2 p-2 bg-gray-50 rounded">
-                    <h4 className="font-semibold text-blue-600">Description:</h4>
-                    <p className="text-sm">{missing.description}</p>
+                  <div className="mt-2 p-2 bg-amber-400/8 border border-amber-300/15 rounded-xl">
+                    <h4 className="font-semibold text-amber-300">Description:</h4>
+                    <p className="text-sm text-amber-100/80">{missing.description}</p>
                     {missing.last_known_address && (
                       <>
-                        <h4 className="font-semibold mt-2">Last Known Address:</h4>
-                        <p className="text-sm">{missing.last_known_address}</p>
+                        <h4 className="font-semibold mt-2 text-amber-200">Last Known Address:</h4>
+                        <p className="text-sm text-amber-100/80">{missing.last_known_address}</p>
                       </>
                     )}
                   </div>

--- a/src/app/admin/missing/page.tsx
+++ b/src/app/admin/missing/page.tsx
@@ -105,7 +105,7 @@ const Page = () => {
 
   return (
     <main className="font-nunito py-3 m-2 rounded-3xl">
-      <h1 className="text-2xl font-bold rounded-3xl border border-amber-300/30 bg-amber-400/10 backdrop-blur-sm py-2 text-center text-amber-50">Missing Persons</h1>
+      <h1 className="text-2xl font-bold rounded-3xl border border-white/50 bg-white/25 backdrop-blur-md py-2 text-center text-amber-950 shadow-sm">Missing Persons</h1>
       <div className="flex p-2 mb-4 justify-around">
         <Button
           className="font-bold text-lg"
@@ -146,27 +146,27 @@ const Page = () => {
         <div className="w-full">
           {loading ? (
             <div className="flex justify-center py-8">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-400"></div>
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-800"></div>
             </div>
           ) : error ? (
-            <div className="text-red-300 text-center py-4">
+            <div className="text-red-800 text-center py-4">
               Error: {error}
               <button
                 onClick={fetchMissingPersons}
-                className="block mx-auto mt-2 bg-amber-400/20 backdrop-blur-sm border border-amber-300/30 text-amber-50 px-4 py-2 rounded-xl hover:bg-amber-400/30 transition-all duration-200"
+                className="block mx-auto mt-2 bg-white/35 backdrop-blur-md border border-white/60 text-amber-950 px-4 py-2 rounded-xl hover:bg-white/50 transition-all duration-200 shadow-sm"
               >
                 Retry
               </button>
             </div>
           ) : missings.length === 0 ? (
-            <div className="text-center py-8 text-amber-300/60">
+            <div className="text-center py-8 text-amber-900/70">
               No missing persons reported
             </div>
           ) : (
             missings.map((missing) => (
               <div
                 key={missing.id}
-                className="bg-amber-400/10 backdrop-blur-md border border-amber-300/20 text-amber-50 rounded-3xl py-2 px-4 my-2 shadow-[0_4px_16px_rgba(217,119,6,0.1)]"
+                className="bg-white/25 backdrop-blur-xl border border-white/50 text-amber-950 rounded-3xl py-2 px-4 my-2 shadow-[0_4px_16px_rgba(120,72,10,0.12)]"
               >
                 <MissingListItem 
                   name={missing.name}
@@ -177,13 +177,13 @@ const Page = () => {
                   image={missing.image}
                 />
                 {missing.description && (
-                  <div className="mt-2 p-2 bg-amber-400/8 border border-amber-300/15 rounded-xl">
-                    <h4 className="font-semibold text-amber-300">Description:</h4>
-                    <p className="text-sm text-amber-100/80">{missing.description}</p>
+                  <div className="mt-2 p-2 bg-white/30 border border-white/50 rounded-xl">
+                    <h4 className="font-semibold text-amber-800">Description:</h4>
+                    <p className="text-sm text-amber-900/90">{missing.description}</p>
                     {missing.last_known_address && (
                       <>
-                        <h4 className="font-semibold mt-2 text-amber-200">Last Known Address:</h4>
-                        <p className="text-sm text-amber-100/80">{missing.last_known_address}</p>
+                        <h4 className="font-semibold mt-2 text-amber-800">Last Known Address:</h4>
+                        <p className="text-sm text-amber-900/90">{missing.last_known_address}</p>
                       </>
                     )}
                   </div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -67,7 +67,7 @@ const Page = () => {
         >
           <svg
             aria-hidden="true"
-            className="w-8 h-8 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600"
+            className="w-8 h-8 text-amber-900/40 animate-spin fill-amber-400"
             viewBox="0 0 100 101"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
@@ -85,19 +85,19 @@ const Page = () => {
         </div>
       ) : (
         <div className="w-full font-nunito text-lg">
-          <h1 className="underline font-bold text-5xl pb-4 mb-4 text-center">ADMIN DASHBOARD</h1>
+          <h1 className="font-bold text-5xl pb-4 mb-4 text-center text-amber-50 drop-shadow-[0_2px_12px_rgba(251,191,36,0.3)]">ADMIN DASHBOARD</h1>
 
-          <div className="flex flex-wrap w-full p-4 rounded-lg gap-4">
-            <div className="w-full md:w-1/3 lg:w-1/4 min-h-80 hover:cursor-pointer">
-              <p className="text-center text-3xl font-bold">Missing : {numberOfMissings ? numberOfMissings : "Loading..."}</p>
+          <div className="flex flex-wrap w-full p-4 rounded-2xl gap-4 bg-amber-400/8 backdrop-blur-md border border-amber-300/15">
+            <div className="w-full md:w-1/3 lg:w-1/4 min-h-80 hover:cursor-pointer bg-amber-400/10 backdrop-blur-sm border border-amber-300/20 rounded-3xl p-3">
+              <p className="text-center text-3xl font-bold text-amber-100">Missing : {numberOfMissings ? numberOfMissings : "Loading..."}</p>
               <img src="/thumbnails/missingThumbnail.png" alt="Missing Person Thumbnail" className="rounded-lg" />
             </div>
-            <div className="w-full md:w-1/3 lg:w-1/4 min-h-80 hover:cursor-pointer">
-              <p className="text-center text-3xl font-bold">Wanted : {numberOfWanteds ? numberOfWanteds : "Loading..."}</p>
+            <div className="w-full md:w-1/3 lg:w-1/4 min-h-80 hover:cursor-pointer bg-amber-400/10 backdrop-blur-sm border border-amber-300/20 rounded-3xl p-3">
+              <p className="text-center text-3xl font-bold text-amber-100">Wanted : {numberOfWanteds ? numberOfWanteds : "Loading..."}</p>
               <img src="/thumbnails/wantedThumbnail3.png" alt="Wanted Person Thumbnail" className="rounded-3xl" />
             </div>
-            <div className="w-full md:w-1/3 lg:w-1/4 min-h-80 hover:cursor-pointer">
-              <p className="text-center text-3xl font-bold">Tips : {numberOfMessages ? numberOfMessages : "Loading..."}</p>
+            <div className="w-full md:w-1/3 lg:w-1/4 min-h-80 hover:cursor-pointer bg-amber-400/10 backdrop-blur-sm border border-amber-300/20 rounded-3xl p-3">
+              <p className="text-center text-3xl font-bold text-amber-100">Tips : {numberOfMessages ? numberOfMessages : "Loading..."}</p>
               <img src="/thumbnails/tips.png" alt="Messages Thumbnail" className="rounded-xl" />
             </div>
           </div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -67,7 +67,7 @@ const Page = () => {
         >
           <svg
             aria-hidden="true"
-            className="w-8 h-8 text-amber-900/40 animate-spin fill-amber-400"
+            className="w-8 h-8 text-amber-950/20 animate-spin fill-amber-700"
             viewBox="0 0 100 101"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
@@ -85,19 +85,19 @@ const Page = () => {
         </div>
       ) : (
         <div className="w-full font-nunito text-lg">
-          <h1 className="font-bold text-5xl pb-4 mb-4 text-center text-amber-50 drop-shadow-[0_2px_12px_rgba(251,191,36,0.3)]">ADMIN DASHBOARD</h1>
+          <h1 className="font-bold text-5xl pb-4 mb-4 text-center text-amber-950 drop-shadow-[0_2px_10px_rgba(255,255,255,0.5)]">ADMIN DASHBOARD</h1>
 
-          <div className="flex flex-wrap w-full p-4 rounded-2xl gap-4 bg-amber-400/8 backdrop-blur-md border border-amber-300/15">
-            <div className="w-full md:w-1/3 lg:w-1/4 min-h-80 hover:cursor-pointer bg-amber-400/10 backdrop-blur-sm border border-amber-300/20 rounded-3xl p-3">
-              <p className="text-center text-3xl font-bold text-amber-100">Missing : {numberOfMissings ? numberOfMissings : "Loading..."}</p>
+          <div className="flex flex-wrap w-full p-4 rounded-2xl gap-4 bg-white/20 backdrop-blur-xl border border-white/50">
+            <div className="w-full md:w-1/3 lg:w-1/4 min-h-80 hover:cursor-pointer bg-white/30 backdrop-blur-md border border-white/50 rounded-3xl p-3 hover:bg-white/40 transition-all duration-200">
+              <p className="text-center text-3xl font-bold text-amber-950">Missing : {numberOfMissings ? numberOfMissings : "Loading..."}</p>
               <img src="/thumbnails/missingThumbnail.png" alt="Missing Person Thumbnail" className="rounded-lg" />
             </div>
-            <div className="w-full md:w-1/3 lg:w-1/4 min-h-80 hover:cursor-pointer bg-amber-400/10 backdrop-blur-sm border border-amber-300/20 rounded-3xl p-3">
-              <p className="text-center text-3xl font-bold text-amber-100">Wanted : {numberOfWanteds ? numberOfWanteds : "Loading..."}</p>
+            <div className="w-full md:w-1/3 lg:w-1/4 min-h-80 hover:cursor-pointer bg-white/30 backdrop-blur-md border border-white/50 rounded-3xl p-3 hover:bg-white/40 transition-all duration-200">
+              <p className="text-center text-3xl font-bold text-amber-950">Wanted : {numberOfWanteds ? numberOfWanteds : "Loading..."}</p>
               <img src="/thumbnails/wantedThumbnail3.png" alt="Wanted Person Thumbnail" className="rounded-3xl" />
             </div>
-            <div className="w-full md:w-1/3 lg:w-1/4 min-h-80 hover:cursor-pointer bg-amber-400/10 backdrop-blur-sm border border-amber-300/20 rounded-3xl p-3">
-              <p className="text-center text-3xl font-bold text-amber-100">Tips : {numberOfMessages ? numberOfMessages : "Loading..."}</p>
+            <div className="w-full md:w-1/3 lg:w-1/4 min-h-80 hover:cursor-pointer bg-white/30 backdrop-blur-md border border-white/50 rounded-3xl p-3 hover:bg-white/40 transition-all duration-200">
+              <p className="text-center text-3xl font-bold text-amber-950">Tips : {numberOfMessages ? numberOfMessages : "Loading..."}</p>
               <img src="/thumbnails/tips.png" alt="Messages Thumbnail" className="rounded-xl" />
             </div>
           </div>

--- a/src/app/admin/wanted/page.tsx
+++ b/src/app/admin/wanted/page.tsx
@@ -106,7 +106,7 @@ const Page = () => {
 
   return (
     <main className="font-nunito py-3 m-2 rounded-3xl">
-      <h1 className="text-2xl font-bold rounded-3xl border border-amber-300/30 bg-amber-400/10 backdrop-blur-sm py-2 text-center text-amber-50">Wanted Persons</h1>
+      <h1 className="text-2xl font-bold rounded-3xl border border-white/50 bg-white/25 backdrop-blur-md py-2 text-center text-amber-950 shadow-sm">Wanted Persons</h1>
       <div className="flex p-2 mb-4 justify-around">
         <Button
           className="font-bold text-lg"
@@ -152,27 +152,27 @@ const Page = () => {
         <div className="w-full">
           {loading ? (
             <div className="flex justify-center py-8">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-400"></div>
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-800"></div>
             </div>
           ) : error ? (
-            <div className="text-red-300 text-center py-4">
+            <div className="text-red-800 text-center py-4">
               Error: {error}
               <button
                 onClick={fetchWantedPersons}
-                className="block mx-auto mt-2 bg-amber-400/20 backdrop-blur-sm border border-amber-300/30 text-amber-50 px-4 py-2 rounded-xl hover:bg-amber-400/30 transition-all duration-200"
+                className="block mx-auto mt-2 bg-white/35 backdrop-blur-md border border-white/60 text-amber-950 px-4 py-2 rounded-xl hover:bg-white/50 transition-all duration-200 shadow-sm"
               >
                 Retry
               </button>
             </div>
           ) : wanteds.length === 0 ? (
-            <div className="text-center py-8 text-amber-300/60">
+            <div className="text-center py-8 text-amber-900/70">
               No wanted persons reported
             </div>
           ) : (
             wanteds.map((wanted) => (
               <div
                 key={wanted.id}
-                className="bg-amber-400/10 backdrop-blur-md border border-amber-300/20 text-amber-50 rounded-3xl py-2 px-4 my-2 shadow-[0_4px_16px_rgba(217,119,6,0.1)]"
+                className="bg-white/25 backdrop-blur-xl border border-white/50 text-amber-950 rounded-3xl py-2 px-4 my-2 shadow-[0_4px_16px_rgba(120,72,10,0.12)]"
               >
                 <MissingListItem
                   name={wanted.name}
@@ -182,19 +182,19 @@ const Page = () => {
                   alias={wanted.alias}
                   image={wanted.image}
                 />
-                <div className="mt-2 p-2 bg-amber-400/8 border border-amber-300/15 rounded-xl">
-                  <h4 className="font-semibold text-red-300">Wanted For:</h4>
-                  <p className="text-sm text-amber-100/80">{wanted.wanted_for}</p>
+                <div className="mt-2 p-2 bg-white/30 border border-white/50 rounded-xl">
+                  <h4 className="font-semibold text-red-700">Wanted For:</h4>
+                  <p className="text-sm text-amber-900/90">{wanted.wanted_for}</p>
                   {wanted.description && (
                     <>
-                      <h4 className="font-semibold mt-2 text-amber-200">Description:</h4>
-                      <p className="text-sm text-amber-100/80">{wanted.description}</p>
+                      <h4 className="font-semibold mt-2 text-amber-800">Description:</h4>
+                      <p className="text-sm text-amber-900/90">{wanted.description}</p>
                     </>
                   )}
                   {wanted.last_known_address && (
                     <>
-                      <h4 className="font-semibold mt-2 text-amber-200">Last Known Address:</h4>
-                      <p className="text-sm text-amber-100/80">{wanted.last_known_address}</p>
+                      <h4 className="font-semibold mt-2 text-amber-800">Last Known Address:</h4>
+                      <p className="text-sm text-amber-900/90">{wanted.last_known_address}</p>
                     </>
                   )}
                 </div>

--- a/src/app/admin/wanted/page.tsx
+++ b/src/app/admin/wanted/page.tsx
@@ -106,7 +106,7 @@ const Page = () => {
 
   return (
     <main className="font-nunito py-3 m-2 rounded-3xl">
-      <h1 className="text-2xl font-bold rounded-3xl border-2 border-black py-2 text-center">Wanted Persons</h1>
+      <h1 className="text-2xl font-bold rounded-3xl border border-amber-300/30 bg-amber-400/10 backdrop-blur-sm py-2 text-center text-amber-50">Wanted Persons</h1>
       <div className="flex p-2 mb-4 justify-around">
         <Button
           className="font-bold text-lg"
@@ -152,27 +152,27 @@ const Page = () => {
         <div className="w-full">
           {loading ? (
             <div className="flex justify-center py-8">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900"></div>
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-400"></div>
             </div>
           ) : error ? (
-            <div className="text-red-600 text-center py-4">
+            <div className="text-red-300 text-center py-4">
               Error: {error}
               <button
                 onClick={fetchWantedPersons}
-                className="block mx-auto mt-2 bg-blue-500 text-white px-4 py-2 rounded"
+                className="block mx-auto mt-2 bg-amber-400/20 backdrop-blur-sm border border-amber-300/30 text-amber-50 px-4 py-2 rounded-xl hover:bg-amber-400/30 transition-all duration-200"
               >
                 Retry
               </button>
             </div>
           ) : wanteds.length === 0 ? (
-            <div className="text-center py-8 text-gray-500">
+            <div className="text-center py-8 text-amber-300/60">
               No wanted persons reported
             </div>
           ) : (
             wanteds.map((wanted) => (
               <div
                 key={wanted.id}
-                className="bg-white text-black rounded-3xl py-2 px-4 my-2"
+                className="bg-amber-400/10 backdrop-blur-md border border-amber-300/20 text-amber-50 rounded-3xl py-2 px-4 my-2 shadow-[0_4px_16px_rgba(217,119,6,0.1)]"
               >
                 <MissingListItem
                   name={wanted.name}
@@ -182,19 +182,19 @@ const Page = () => {
                   alias={wanted.alias}
                   image={wanted.image}
                 />
-                <div className="mt-2 p-2 bg-gray-50 rounded">
-                  <h4 className="font-semibold text-red-600">Wanted For:</h4>
-                  <p className="text-sm">{wanted.wanted_for}</p>
+                <div className="mt-2 p-2 bg-amber-400/8 border border-amber-300/15 rounded-xl">
+                  <h4 className="font-semibold text-red-300">Wanted For:</h4>
+                  <p className="text-sm text-amber-100/80">{wanted.wanted_for}</p>
                   {wanted.description && (
                     <>
-                      <h4 className="font-semibold mt-2">Description:</h4>
-                      <p className="text-sm">{wanted.description}</p>
+                      <h4 className="font-semibold mt-2 text-amber-200">Description:</h4>
+                      <p className="text-sm text-amber-100/80">{wanted.description}</p>
                     </>
                   )}
                   {wanted.last_known_address && (
                     <>
-                      <h4 className="font-semibold mt-2">Last Known Address:</h4>
-                      <p className="text-sm">{wanted.last_known_address}</p>
+                      <h4 className="font-semibold mt-2 text-amber-200">Last Known Address:</h4>
+                      <p className="text-sm text-amber-100/80">{wanted.last_known_address}</p>
                     </>
                   )}
                 </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,27 +13,21 @@
 }
 
 :root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 241, 214, 98;
-  --background-end-rgb: 240, 220, 100;
+  --foreground-rgb: 255, 241, 204;
+  --background-start-rgb: 120, 53, 15;
+  --background-end-rgb: 12, 6, 2;
 }
-
-/* @media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
-} */
 
 body {
   color: rgb(var(--foreground-rgb));
   background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
+    145deg,
+    rgb(var(--background-start-rgb)) 0%,
+    rgb(69, 26, 3) 50%,
+    rgb(var(--background-end-rgb)) 100%
+  );
+  min-height: 100vh;
+  background-attachment: fixed;
 }
 
 @layer utilities {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,9 +13,9 @@
 }
 
 :root {
-  --foreground-rgb: 255, 241, 204;
-  --background-start-rgb: 120, 53, 15;
-  --background-end-rgb: 12, 6, 2;
+  --foreground-rgb: 51, 28, 4;
+  --background-start-rgb: 253, 224, 71;
+  --background-end-rgb: 245, 158, 11;
 }
 
 body {
@@ -23,7 +23,7 @@ body {
   background: linear-gradient(
     145deg,
     rgb(var(--background-start-rgb)) 0%,
-    rgb(69, 26, 3) 50%,
+    rgb(251, 191, 36) 50%,
     rgb(var(--background-end-rgb)) 100%
   );
   min-height: 100vh;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,25 +21,25 @@ export default function Home() {
 
   return (
     <main className="flex min-h-screen flex-col items-center p-4 md:p-12 lg:p-24">
-      <h1 className="md:text-6xl lg:text-8xl text-4xl font-nunito font-extrabold mb-10 w-screen text-center">
+      <h1 className="md:text-6xl lg:text-8xl text-4xl font-nunito font-extrabold mb-10 w-screen text-center text-amber-50 drop-shadow-[0_2px_16px_rgba(251,191,36,0.4)]">
         Crack Crime Bahamas
       </h1>
-      <section className="bg-white dark:bg-gray-900 rounded-lg font-nunito mb-10 w-full">
+      <section className="bg-amber-400/10 backdrop-blur-md border border-amber-300/20 rounded-2xl font-nunito mb-10 w-full shadow-[0_8px_32px_rgba(217,119,6,0.1)]">
         <div className="grid w-full px-4 py-8 mx-auto lg:gap-8 xl:gap-0 lg:py-16 lg:grid-cols-12">
           <div className="mr-auto place-self-center lg:col-span-7">
-            <h1 className="max-w-2xl mb-4 text-4xl font-extrabold tracking-tight leading-none md:text-3xl xl:text-5xl text-black">
+            <h1 className="max-w-2xl mb-4 text-4xl font-extrabold tracking-tight leading-none md:text-3xl xl:text-5xl text-amber-50">
               Crime Stoppers Bahamas
             </h1>
-            <p className="max-w-2xl mb-6 font-light text-gray-500 lg:mb-8 md:text-lg lg:text-xl dark:text-gray-400">
+            <p className="max-w-2xl mb-6 font-light text-amber-200/80 lg:mb-8 md:text-lg lg:text-xl">
               The worst amongst us have no chance of perpetrating any criminal
               acts if the the rest of us come together.
             </p>
             <Button
               onPress={appDownloader}
               radius="md"
-              //className="hover:shadow-gray-500 shadow-md bg-yellow-300"
               variant="solid"
-              color="primary"
+              color="warning"
+              className="bg-amber-400/25 backdrop-blur-sm border border-amber-300/40 text-amber-50 hover:bg-amber-400/40 font-bold"
             >
               <span className="font-bold text-lg">Download App</span>
               <svg
@@ -90,13 +90,13 @@ export default function Home() {
           </div>
         </div>
       </section>
-      <section className="bg-white dark:bg-gray-900 rounded-lg font-nunito mb-10">
+      <section className="bg-amber-400/10 backdrop-blur-md border border-amber-300/20 rounded-2xl font-nunito mb-10 shadow-[0_8px_32px_rgba(217,119,6,0.1)]">
         <div className="py-8 px-4 mx-auto max-w-screen-xl sm:py-16 lg:px-6">
           <div className="max-w-screen-md mb-8 lg:mb-16">
-            <h2 className="mb-4 text-4xl tracking-tight font-extrabold text-gray-900 dark:text-white">
+            <h2 className="mb-4 text-4xl tracking-tight font-extrabold text-amber-50">
               Features of our App
             </h2>
-            <p className="text-gray-500 sm:text-xl dark:text-gray-400">
+            <p className="text-amber-200/75 sm:text-xl">
               We here at Crack Crime Bahamas believe that safety is one of the
               fundamental human rights and are steadfast in our commitment to
               keeping our communities safe.
@@ -104,10 +104,10 @@ export default function Home() {
           </div>
           <div className="space-y-8 md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-12 md:space-y-0">
             <div>
-              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-primary-100 lg:h-12 lg:w-12 dark:bg-primary-900">
+              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-amber-400/20 border border-amber-300/30 lg:h-12 lg:w-12">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  className="h-8 w-8 text-black"
+                  className="h-8 w-8 text-amber-200"
                   viewBox="0 0 20 24"
                 >
                   <path
@@ -116,18 +116,18 @@ export default function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="mb-2 text-xl font-bold text-black">
+              <h3 className="mb-2 text-xl font-bold text-amber-50">
                 Anonymity
               </h3>
-              <p className="text-gray-500 dark:text-gray-400">
+              <p className="text-amber-200/75">
                 Helpful in stopping crime and keeping you safe
               </p>
             </div>
             <div>
-              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-primary-100 lg:h-12 lg:w-12 dark:bg-primary-900">
+              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-amber-400/20 border border-amber-300/30 lg:h-12 lg:w-12">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  className="h-8 w-8 text-black"
+                  className="h-8 w-8 text-amber-200"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -136,19 +136,19 @@ export default function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="mb-2 text-xl font-bold text-black">
+              <h3 className="mb-2 text-xl font-bold text-amber-50">
                 Privacy
               </h3>
-              <p className="text-gray-500 dark:text-gray-400">
+              <p className="text-amber-200/75">
                 Your data is your own and you have a right to choose what data
                 you share with us and can delete it whenever you want.
               </p>
             </div>
             <div>
-              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-primary-100 lg:h-12 lg:w-12 dark:bg-primary-900">
+              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-amber-400/20 border border-amber-300/30 lg:h-12 lg:w-12">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  className="h-8 w-8 text-black"
+                  className="h-8 w-8 text-amber-200"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -157,19 +157,19 @@ export default function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="mb-2 text-xl font-bold text-black">
+              <h3 className="mb-2 text-xl font-bold text-amber-50">
                 Encryption
               </h3>
-              <p className="text-gray-500 dark:text-gray-400">
+              <p className="text-amber-200/75">
                 We encrypt any messages you send from our App hence it is not
                 prone to hackers and eliminates personal risk.
               </p>
             </div>
             <div>
-              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-primary-100 lg:h-12 lg:w-12 dark:bg-primary-900">
+              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-amber-400/20 border border-amber-300/30 lg:h-12 lg:w-12">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  className="h-8 w-8 text-black"
+                  className="h-8 w-8 text-amber-200"
                   viewBox="0 0 32 32"
                 >
                   <path
@@ -178,18 +178,18 @@ export default function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="mb-2 text-xl font-bold text-black">Events</h3>
-              <p className="text-gray-500 dark:text-gray-400">
+              <h3 className="mb-2 text-xl font-bold text-amber-50">Events</h3>
+              <p className="text-amber-200/75">
                 We also conduct events as part of our ongoing efforts in
                 community building, thus you shall not feel alone in fighting
                 crime.
               </p>
             </div>
             <div>
-              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-primary-100 lg:h-12 lg:w-12 dark:bg-primary-900">
+              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-amber-400/20 border border-amber-300/30 lg:h-12 lg:w-12">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  className="h-8 w-8 text-black"
+                  className="h-8 w-8 text-amber-200"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -198,16 +198,16 @@ export default function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="mb-2 text-xl font-bold text-black">
+              <h3 className="mb-2 text-xl font-bold text-amber-50">
                 Support
               </h3>
-              <p className="text-gray-500 dark:text-gray-400">
+              <p className="text-amber-200/75">
                 We strive to provide support to the most vulnerable amongst us
                 and you can contact us anytime of the day.
               </p>
             </div>
             <div>
-              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-primary-100 lg:h-12 lg:w-12 dark:bg-primary-900">
+              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-amber-400/20 border border-amber-300/30 lg:h-12 lg:w-12">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   className="w-8 h-8 text-black"
@@ -219,10 +219,10 @@ export default function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="mb-2 text-xl font-bold text-black">
+              <h3 className="mb-2 text-xl font-bold text-amber-50">
                 Rewards
               </h3>
-              <p className="text-gray-500 dark:text-gray-400">
+              <p className="text-amber-200/75">
                 Heroic deeds should be incentivized and motivated hence we have
                 a rewards programme for helpful information that leads to an
                 arrest
@@ -231,10 +231,10 @@ export default function Home() {
           </div>
         </div>
       </section>
-      <section className="bg-white dark:bg-gray-900 rounded-lg font-nunito mb-10">
+      <section className="bg-amber-400/10 backdrop-blur-md border border-amber-300/20 rounded-2xl font-nunito mb-10 shadow-[0_8px_32px_rgba(217,119,6,0.1)]">
         <div className="gap-16 items-center py-8 px-4 mx-auto max-w-screen-xl lg:grid lg:grid-cols-2 lg:py-16 lg:px-6">
-          <div className="font-light text-gray-500 sm:text-lg dark:text-gray-400">
-            <h2 className="mb-4 text-4xl tracking-tight font-extrabold text-gray-900 dark:text-white">
+          <div className="font-light text-amber-200/80 sm:text-lg">
+            <h2 className="mb-4 text-4xl tracking-tight font-extrabold text-amber-50">
               Meet the Team
             </h2>
             <p className="mb-4">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,16 +21,16 @@ export default function Home() {
 
   return (
     <main className="flex min-h-screen flex-col items-center p-4 md:p-12 lg:p-24">
-      <h1 className="md:text-6xl lg:text-8xl text-4xl font-nunito font-extrabold mb-10 w-screen text-center text-amber-50 drop-shadow-[0_2px_16px_rgba(251,191,36,0.4)]">
+      <h1 className="md:text-6xl lg:text-8xl text-4xl font-nunito font-extrabold mb-10 w-screen text-center text-amber-950 drop-shadow-[0_2px_10px_rgba(255,255,255,0.55)]">
         Crack Crime Bahamas
       </h1>
-      <section className="bg-amber-400/10 backdrop-blur-md border border-amber-300/20 rounded-2xl font-nunito mb-10 w-full shadow-[0_8px_32px_rgba(217,119,6,0.1)]">
+      <section className="bg-white/20 backdrop-blur-xl border border-white/50 rounded-2xl font-nunito mb-10 w-full shadow-[0_8px_32px_rgba(120,72,10,0.12)]">
         <div className="grid w-full px-4 py-8 mx-auto lg:gap-8 xl:gap-0 lg:py-16 lg:grid-cols-12">
           <div className="mr-auto place-self-center lg:col-span-7">
-            <h1 className="max-w-2xl mb-4 text-4xl font-extrabold tracking-tight leading-none md:text-3xl xl:text-5xl text-amber-50">
+            <h1 className="max-w-2xl mb-4 text-4xl font-extrabold tracking-tight leading-none md:text-3xl xl:text-5xl text-amber-950">
               Crime Stoppers Bahamas
             </h1>
-            <p className="max-w-2xl mb-6 font-light text-amber-200/80 lg:mb-8 md:text-lg lg:text-xl">
+            <p className="max-w-2xl mb-6 font-light text-amber-900/80 lg:mb-8 md:text-lg lg:text-xl">
               The worst amongst us have no chance of perpetrating any criminal
               acts if the the rest of us come together.
             </p>
@@ -39,7 +39,7 @@ export default function Home() {
               radius="md"
               variant="solid"
               color="warning"
-              className="bg-amber-400/25 backdrop-blur-sm border border-amber-300/40 text-amber-50 hover:bg-amber-400/40 font-bold"
+              className="bg-white/40 backdrop-blur-md border border-white/60 text-amber-950 hover:bg-white/55 font-bold shadow-md"
             >
               <span className="font-bold text-lg">Download App</span>
               <svg
@@ -90,13 +90,13 @@ export default function Home() {
           </div>
         </div>
       </section>
-      <section className="bg-amber-400/10 backdrop-blur-md border border-amber-300/20 rounded-2xl font-nunito mb-10 shadow-[0_8px_32px_rgba(217,119,6,0.1)]">
+      <section className="bg-white/20 backdrop-blur-xl border border-white/50 rounded-2xl font-nunito mb-10 shadow-[0_8px_32px_rgba(120,72,10,0.12)]">
         <div className="py-8 px-4 mx-auto max-w-screen-xl sm:py-16 lg:px-6">
           <div className="max-w-screen-md mb-8 lg:mb-16">
-            <h2 className="mb-4 text-4xl tracking-tight font-extrabold text-amber-50">
+            <h2 className="mb-4 text-4xl tracking-tight font-extrabold text-amber-950">
               Features of our App
             </h2>
-            <p className="text-amber-200/75 sm:text-xl">
+            <p className="text-amber-900/80 sm:text-xl">
               We here at Crack Crime Bahamas believe that safety is one of the
               fundamental human rights and are steadfast in our commitment to
               keeping our communities safe.
@@ -104,10 +104,10 @@ export default function Home() {
           </div>
           <div className="space-y-8 md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-12 md:space-y-0">
             <div>
-              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-amber-400/20 border border-amber-300/30 lg:h-12 lg:w-12">
+              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-white/40 border border-white/60 lg:h-12 lg:w-12">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  className="h-8 w-8 text-amber-200"
+                  className="h-8 w-8 text-amber-900"
                   viewBox="0 0 20 24"
                 >
                   <path
@@ -116,18 +116,18 @@ export default function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="mb-2 text-xl font-bold text-amber-50">
+              <h3 className="mb-2 text-xl font-bold text-amber-950">
                 Anonymity
               </h3>
-              <p className="text-amber-200/75">
+              <p className="text-amber-900/80">
                 Helpful in stopping crime and keeping you safe
               </p>
             </div>
             <div>
-              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-amber-400/20 border border-amber-300/30 lg:h-12 lg:w-12">
+              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-white/40 border border-white/60 lg:h-12 lg:w-12">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  className="h-8 w-8 text-amber-200"
+                  className="h-8 w-8 text-amber-900"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -136,19 +136,19 @@ export default function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="mb-2 text-xl font-bold text-amber-50">
+              <h3 className="mb-2 text-xl font-bold text-amber-950">
                 Privacy
               </h3>
-              <p className="text-amber-200/75">
+              <p className="text-amber-900/80">
                 Your data is your own and you have a right to choose what data
                 you share with us and can delete it whenever you want.
               </p>
             </div>
             <div>
-              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-amber-400/20 border border-amber-300/30 lg:h-12 lg:w-12">
+              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-white/40 border border-white/60 lg:h-12 lg:w-12">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  className="h-8 w-8 text-amber-200"
+                  className="h-8 w-8 text-amber-900"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -157,19 +157,19 @@ export default function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="mb-2 text-xl font-bold text-amber-50">
+              <h3 className="mb-2 text-xl font-bold text-amber-950">
                 Encryption
               </h3>
-              <p className="text-amber-200/75">
+              <p className="text-amber-900/80">
                 We encrypt any messages you send from our App hence it is not
                 prone to hackers and eliminates personal risk.
               </p>
             </div>
             <div>
-              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-amber-400/20 border border-amber-300/30 lg:h-12 lg:w-12">
+              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-white/40 border border-white/60 lg:h-12 lg:w-12">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  className="h-8 w-8 text-amber-200"
+                  className="h-8 w-8 text-amber-900"
                   viewBox="0 0 32 32"
                 >
                   <path
@@ -178,18 +178,18 @@ export default function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="mb-2 text-xl font-bold text-amber-50">Events</h3>
-              <p className="text-amber-200/75">
+              <h3 className="mb-2 text-xl font-bold text-amber-950">Events</h3>
+              <p className="text-amber-900/80">
                 We also conduct events as part of our ongoing efforts in
                 community building, thus you shall not feel alone in fighting
                 crime.
               </p>
             </div>
             <div>
-              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-amber-400/20 border border-amber-300/30 lg:h-12 lg:w-12">
+              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-white/40 border border-white/60 lg:h-12 lg:w-12">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  className="h-8 w-8 text-amber-200"
+                  className="h-8 w-8 text-amber-900"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -198,16 +198,16 @@ export default function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="mb-2 text-xl font-bold text-amber-50">
+              <h3 className="mb-2 text-xl font-bold text-amber-950">
                 Support
               </h3>
-              <p className="text-amber-200/75">
+              <p className="text-amber-900/80">
                 We strive to provide support to the most vulnerable amongst us
                 and you can contact us anytime of the day.
               </p>
             </div>
             <div>
-              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-amber-400/20 border border-amber-300/30 lg:h-12 lg:w-12">
+              <div className="flex justify-center items-center mb-4 w-10 h-10 rounded-full bg-white/40 border border-white/60 lg:h-12 lg:w-12">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   className="w-8 h-8 text-black"
@@ -219,10 +219,10 @@ export default function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="mb-2 text-xl font-bold text-amber-50">
+              <h3 className="mb-2 text-xl font-bold text-amber-950">
                 Rewards
               </h3>
-              <p className="text-amber-200/75">
+              <p className="text-amber-900/80">
                 Heroic deeds should be incentivized and motivated hence we have
                 a rewards programme for helpful information that leads to an
                 arrest
@@ -231,10 +231,10 @@ export default function Home() {
           </div>
         </div>
       </section>
-      <section className="bg-amber-400/10 backdrop-blur-md border border-amber-300/20 rounded-2xl font-nunito mb-10 shadow-[0_8px_32px_rgba(217,119,6,0.1)]">
+      <section className="bg-white/20 backdrop-blur-xl border border-white/50 rounded-2xl font-nunito mb-10 shadow-[0_8px_32px_rgba(120,72,10,0.12)]">
         <div className="gap-16 items-center py-8 px-4 mx-auto max-w-screen-xl lg:grid lg:grid-cols-2 lg:py-16 lg:px-6">
-          <div className="font-light text-amber-200/80 sm:text-lg">
-            <h2 className="mb-4 text-4xl tracking-tight font-extrabold text-amber-50">
+          <div className="font-light text-amber-900/80 sm:text-lg">
+            <h2 className="mb-4 text-4xl tracking-tight font-extrabold text-amber-950">
               Meet the Team
             </h2>
             <p className="mb-4">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,29 +3,29 @@ import Modal from "./Modal";
 export default function Footer() {
   return (
     <div className="w-full pb-14 md:pb-0">
-      <footer className="p-4 bg-white sm:p-6 dark:bg-gray-800">
+      <footer className="p-4 bg-amber-950/60 backdrop-blur-md border-t border-amber-300/20 sm:p-6">
         <div className="mx-auto max-w-screen-xl">
           <div className="md:flex md:justify-between">
             <div className="mb-6 md:mb-0">
               <a href="/" className="flex items-center">
                 <img src="/newfavicon.png" className="mr-3 h-8" alt="Logo" />
-                <span className="self-center text-2xl font-semibold whitespace-nowrap text-black">
+                <span className="self-center text-2xl font-semibold whitespace-nowrap text-amber-50">
                   CrackCrimeBahamas
                 </span>
               </a>
             </div>
             <div className="grid grid-cols-2 gap-8 sm:gap-6 sm:grid-cols-3">
               <div>
-                <h2 className="mb-6 text-sm font-semibold text-gray-900 uppercase dark:text-white">
+                <h2 className="mb-6 text-sm font-semibold text-amber-200 uppercase">
                   Resources
                 </h2>
-                <ul className="text-gray-600 dark:text-gray-400">
+                <ul className="text-amber-300/70">
                   <li className="mb-4">
                     <a
                       rel="noopener"
                       href="https://www.royalbahamaspolice.org/crimeprevention/"
                       target="_blank"
-                      className="hover:underline"
+                      className="hover:underline hover:text-amber-100 transition-colors duration-200"
                     >
                       Crime Prevention Tips
                     </a>
@@ -33,7 +33,7 @@ export default function Footer() {
                   <li>
                     <a
                       href="https://www.royalbahamaspolice.org/community/announcements/"
-                      className="hover:underline"
+                      className="hover:underline hover:text-amber-100 transition-colors duration-200"
                       target="_blank"
                       rel="noopener"
                     >
@@ -43,10 +43,10 @@ export default function Footer() {
                 </ul>
               </div>
               <div>
-                <h2 className="mb-6 text-sm font-semibold text-gray-900 uppercase dark:text-white">
+                <h2 className="mb-6 text-sm font-semibold text-amber-200 uppercase">
                   More
                 </h2>
-                <ul className="text-gray-600 dark:text-gray-400">
+                <ul className="text-amber-300/70">
                   <li className="mb-4">
                     <a href="/login" className="hover:underline ">
                       Admin Login
@@ -62,17 +62,17 @@ export default function Footer() {
                 </ul>
               </div>
               <div>
-                <h2 className="mb-6 text-sm font-semibold text-gray-900 uppercase dark:text-white">
+                <h2 className="mb-6 text-sm font-semibold text-amber-200 uppercase">
                   Legal
                 </h2>
-                <ul className="text-gray-600 dark:text-gray-400">
+                <ul className="text-amber-300/70">
                   <li className="mb-4">
-                    <a href="/legal/privacy" className="hover:underline">
+                    <a href="/legal/privacy" className="hover:underline hover:text-amber-100 transition-colors duration-200">
                       Privacy Policy
                     </a>
                   </li>
                   <li>
-                    <a href="/legal/terms" className="hover:underline">
+                    <a href="/legal/terms" className="hover:underline hover:text-amber-100 transition-colors duration-200">
                       Terms &amp; Conditions
                     </a>
                   </li>
@@ -80,11 +80,11 @@ export default function Footer() {
               </div>
             </div>
           </div>
-          <hr className="my-6 border-gray-200 sm:mx-auto dark:border-gray-700 lg:my-8" />
+          <hr className="my-6 border-amber-300/20 sm:mx-auto lg:my-8" />
           <div className="sm:flex sm:items-center sm:justify-between">
-            <span className="text-sm text-gray-500 sm:text-center dark:text-gray-400">
+            <span className="text-sm text-amber-300/60 sm:text-center">
               © 2024{" "}
-              <a href="/" className="hover:underline">
+              <a href="/" className="hover:underline hover:text-amber-200 transition-colors duration-200">
                 CrackCrimeBahamas™
               </a>
               . All Rights Reserved.
@@ -92,7 +92,7 @@ export default function Footer() {
             <div className="flex mt-4 space-x-6 sm:justify-center sm:mt-0">
               {/* <a
                 href="#"
-                className="text-gray-500 hover:text-gray-900 dark:hover:text-white"
+                className="text-amber-400/60 hover:text-amber-200 transition-colors duration-200"
               >
                 <svg
                   className="w-5 h-5"
@@ -109,7 +109,7 @@ export default function Footer() {
               </a> */}
               {/* <a
                 href="#"
-                className="text-gray-500 hover:text-gray-900 dark:hover:text-white"
+                className="text-amber-400/60 hover:text-amber-200 transition-colors duration-200"
               >
                 <svg
                   className="w-5 h-5"
@@ -128,7 +128,7 @@ export default function Footer() {
                 href="https://www.crimestoppersbahamas.com/"
                 target="_blank"
                 rel="noopener"
-                className="text-gray-500 hover:text-gray-900 dark:hover:text-white"
+                className="text-amber-400/60 hover:text-amber-200 transition-colors duration-200"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -149,7 +149,7 @@ export default function Footer() {
                 href="https://github.com/SailendraDarbha94/crack-crime-bahamas"
                 target="_blank"
                 rel="noopener"
-                className="text-gray-500 hover:text-gray-900 dark:hover:text-white"
+                className="text-amber-400/60 hover:text-amber-200 transition-colors duration-200"
               >
                 <svg
                   className="w-5 h-5"
@@ -166,7 +166,7 @@ export default function Footer() {
               </a> */}
               {/* <a
                 href="#"
-                className="text-gray-500 hover:text-gray-900 dark:hover:text-white"
+                className="text-amber-400/60 hover:text-amber-200 transition-colors duration-200"
               >
                 <svg
                   className="w-5 h-5"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,29 +3,29 @@ import Modal from "./Modal";
 export default function Footer() {
   return (
     <div className="w-full pb-14 md:pb-0">
-      <footer className="p-4 bg-amber-950/60 backdrop-blur-md border-t border-amber-300/20 sm:p-6">
+      <footer className="p-4 bg-white/15 backdrop-blur-md border-t border-white/40 sm:p-6">
         <div className="mx-auto max-w-screen-xl">
           <div className="md:flex md:justify-between">
             <div className="mb-6 md:mb-0">
               <a href="/" className="flex items-center">
                 <img src="/newfavicon.png" className="mr-3 h-8" alt="Logo" />
-                <span className="self-center text-2xl font-semibold whitespace-nowrap text-amber-50">
+                <span className="self-center text-2xl font-semibold whitespace-nowrap text-amber-950">
                   CrackCrimeBahamas
                 </span>
               </a>
             </div>
             <div className="grid grid-cols-2 gap-8 sm:gap-6 sm:grid-cols-3">
               <div>
-                <h2 className="mb-6 text-sm font-semibold text-amber-200 uppercase">
+                <h2 className="mb-6 text-sm font-semibold text-amber-900 uppercase">
                   Resources
                 </h2>
-                <ul className="text-amber-300/70">
+                <ul className="text-amber-800/80">
                   <li className="mb-4">
                     <a
                       rel="noopener"
                       href="https://www.royalbahamaspolice.org/crimeprevention/"
                       target="_blank"
-                      className="hover:underline hover:text-amber-100 transition-colors duration-200"
+                      className="hover:underline hover:text-amber-950 transition-colors duration-200"
                     >
                       Crime Prevention Tips
                     </a>
@@ -33,7 +33,7 @@ export default function Footer() {
                   <li>
                     <a
                       href="https://www.royalbahamaspolice.org/community/announcements/"
-                      className="hover:underline hover:text-amber-100 transition-colors duration-200"
+                      className="hover:underline hover:text-amber-950 transition-colors duration-200"
                       target="_blank"
                       rel="noopener"
                     >
@@ -43,10 +43,10 @@ export default function Footer() {
                 </ul>
               </div>
               <div>
-                <h2 className="mb-6 text-sm font-semibold text-amber-200 uppercase">
+                <h2 className="mb-6 text-sm font-semibold text-amber-900 uppercase">
                   More
                 </h2>
-                <ul className="text-amber-300/70">
+                <ul className="text-amber-800/80">
                   <li className="mb-4">
                     <a href="/login" className="hover:underline ">
                       Admin Login
@@ -62,17 +62,17 @@ export default function Footer() {
                 </ul>
               </div>
               <div>
-                <h2 className="mb-6 text-sm font-semibold text-amber-200 uppercase">
+                <h2 className="mb-6 text-sm font-semibold text-amber-900 uppercase">
                   Legal
                 </h2>
-                <ul className="text-amber-300/70">
+                <ul className="text-amber-800/80">
                   <li className="mb-4">
-                    <a href="/legal/privacy" className="hover:underline hover:text-amber-100 transition-colors duration-200">
+                    <a href="/legal/privacy" className="hover:underline hover:text-amber-950 transition-colors duration-200">
                       Privacy Policy
                     </a>
                   </li>
                   <li>
-                    <a href="/legal/terms" className="hover:underline hover:text-amber-100 transition-colors duration-200">
+                    <a href="/legal/terms" className="hover:underline hover:text-amber-950 transition-colors duration-200">
                       Terms &amp; Conditions
                     </a>
                   </li>
@@ -80,11 +80,11 @@ export default function Footer() {
               </div>
             </div>
           </div>
-          <hr className="my-6 border-amber-300/20 sm:mx-auto lg:my-8" />
+          <hr className="my-6 border-amber-900/15 sm:mx-auto lg:my-8" />
           <div className="sm:flex sm:items-center sm:justify-between">
-            <span className="text-sm text-amber-300/60 sm:text-center">
+            <span className="text-sm text-amber-800/70 sm:text-center">
               © 2024{" "}
-              <a href="/" className="hover:underline hover:text-amber-200 transition-colors duration-200">
+              <a href="/" className="hover:underline hover:text-amber-950 transition-colors duration-200">
                 CrackCrimeBahamas™
               </a>
               . All Rights Reserved.
@@ -92,7 +92,7 @@ export default function Footer() {
             <div className="flex mt-4 space-x-6 sm:justify-center sm:mt-0">
               {/* <a
                 href="#"
-                className="text-amber-400/60 hover:text-amber-200 transition-colors duration-200"
+                className="text-amber-700/70 hover:text-amber-950 transition-colors duration-200"
               >
                 <svg
                   className="w-5 h-5"
@@ -109,7 +109,7 @@ export default function Footer() {
               </a> */}
               {/* <a
                 href="#"
-                className="text-amber-400/60 hover:text-amber-200 transition-colors duration-200"
+                className="text-amber-700/70 hover:text-amber-950 transition-colors duration-200"
               >
                 <svg
                   className="w-5 h-5"
@@ -128,7 +128,7 @@ export default function Footer() {
                 href="https://www.crimestoppersbahamas.com/"
                 target="_blank"
                 rel="noopener"
-                className="text-amber-400/60 hover:text-amber-200 transition-colors duration-200"
+                className="text-amber-700/70 hover:text-amber-950 transition-colors duration-200"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -149,7 +149,7 @@ export default function Footer() {
                 href="https://github.com/SailendraDarbha94/crack-crime-bahamas"
                 target="_blank"
                 rel="noopener"
-                className="text-amber-400/60 hover:text-amber-200 transition-colors duration-200"
+                className="text-amber-700/70 hover:text-amber-950 transition-colors duration-200"
               >
                 <svg
                   className="w-5 h-5"
@@ -166,7 +166,7 @@ export default function Footer() {
               </a> */}
               {/* <a
                 href="#"
-                className="text-amber-400/60 hover:text-amber-200 transition-colors duration-200"
+                className="text-amber-700/70 hover:text-amber-950 transition-colors duration-200"
               >
                 <svg
                   className="w-5 h-5"

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -11,7 +11,7 @@ const ModalText = ({ isVisible, onClose, children }: any) => {
         className="absolute inset-0 bg-black opacity-70"
         onClick={onClose}
       ></div>
-      <div className="bg-white p-8 rounded-lg shadow-lg z-10">
+      <div className="bg-amber-950/85 backdrop-blur-2xl border border-amber-300/30 p-8 rounded-2xl shadow-[0_20px_60px_rgba(0,0,0,0.5)] z-10">
         {children}
         <span
           className="mt-4 flex justify-center items-center"
@@ -69,8 +69,8 @@ const Modal = ({
         {word}
       </span>
       <ModalText isVisible={isModalVisible} onClose={closeModal}>
-        <h2 className="text-2xl mb-4 dark:text-black font-nunito">{heading}</h2>
-        <p className="font-nunito text-lg text-wrap tracking-wide">
+        <h2 className="text-2xl mb-4 text-amber-50 font-nunito">{heading}</h2>
+        <p className="font-nunito text-lg text-wrap tracking-wide text-amber-200/80">
           {lines &&
             lines.map((line: string, index) => {
               return (

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -11,7 +11,7 @@ const ModalText = ({ isVisible, onClose, children }: any) => {
         className="absolute inset-0 bg-black opacity-70"
         onClick={onClose}
       ></div>
-      <div className="bg-amber-950/85 backdrop-blur-2xl border border-amber-300/30 p-8 rounded-2xl shadow-[0_20px_60px_rgba(0,0,0,0.5)] z-10">
+      <div className="bg-amber-50/90 backdrop-blur-2xl border border-white/60 p-8 rounded-2xl shadow-[0_20px_60px_rgba(0,0,0,0.35)] z-10">
         {children}
         <span
           className="mt-4 flex justify-center items-center"
@@ -69,8 +69,8 @@ const Modal = ({
         {word}
       </span>
       <ModalText isVisible={isModalVisible} onClose={closeModal}>
-        <h2 className="text-2xl mb-4 text-amber-50 font-nunito">{heading}</h2>
-        <p className="font-nunito text-lg text-wrap tracking-wide text-amber-200/80">
+        <h2 className="text-2xl mb-4 text-amber-950 font-nunito">{heading}</h2>
+        <p className="font-nunito text-lg text-wrap tracking-wide text-amber-900/80">
           {lines &&
             lines.map((line: string, index) => {
               return (

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -42,11 +42,11 @@ const Navbar = () => {
 
   return (
     <main
-      className={`fixed md:hidden flex flex-wrap bottom-0 left-0 w-full bg-amber-950/85 backdrop-blur-xl border-t border-amber-400/30 ${height} transition-[height]`}
+      className={`fixed md:hidden flex flex-wrap bottom-0 left-0 w-full bg-amber-50/80 backdrop-blur-xl border-t border-white/50 ${height} transition-[height]`}
     >
       {height === "h-14" ? (
         <div
-          className={`bg-amber-400/15 backdrop-blur-sm w-full h-14 px-4 flex justify-between items-center hover:cursor-pointer`}
+          className={`bg-white/30 backdrop-blur-md text-amber-950 w-full h-14 px-4 flex justify-between items-center hover:cursor-pointer`}
           onClick={toggleNavbar}
         >
           <span className="font-nunito text-2xl font-extrabold flex items-center w-full">
@@ -59,7 +59,7 @@ const Navbar = () => {
           >
             <g
               fill="none"
-              stroke="#fef3c7"
+              stroke="#451a03"
               strokeDasharray="24"
               strokeDashoffset="24"
               strokeLinecap="round"
@@ -80,14 +80,14 @@ const Navbar = () => {
       ) : null}
       {paths.includes("admin") ? (
         <div
-          className="h-14 bg-red-500/20 backdrop-blur-sm border-b border-red-400/30 text-red-200 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
+          className="h-14 bg-red-500/85 backdrop-blur-sm border-b border-red-300/50 text-white w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
           onClick={logoutUser}
         >
           Logout
         </div>
       ) : (
         <div
-          className="h-14 bg-amber-400/20 backdrop-blur-sm border-b border-amber-300/25 text-amber-50 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
+          className="h-14 bg-white/30 backdrop-blur-md border-b border-white/40 text-amber-950 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
           onClick={() => routeNavigator("/")}
         >
           <img src="/newfavicon.png" alt="logo" className="h-8 w-8 mx-2" />
@@ -95,7 +95,7 @@ const Navbar = () => {
         </div>
       )}
       <div
-        className="h-14 bg-amber-400/15 backdrop-blur-sm border-b border-amber-300/20 text-amber-50 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
+        className="h-14 bg-white/25 backdrop-blur-md border-b border-white/40 text-amber-950 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
         onClick={() =>
           paths.includes("admin")
             ? routeNavigator("/admin/missing")
@@ -105,7 +105,7 @@ const Navbar = () => {
         {paths.includes("admin") ? "Add Missing Person" : "Become A Sponsor"}
       </div>
       <div
-        className="h-14 bg-amber-400/12 backdrop-blur-sm border-b border-amber-300/18 text-amber-50 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
+        className="h-14 bg-white/20 backdrop-blur-md border-b border-white/40 text-amber-950 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
         onClick={() =>
           paths.includes("admin")
             ? routeNavigator("/admin/wanted")
@@ -115,7 +115,7 @@ const Navbar = () => {
         {paths.includes("admin") ? "Add Wanted Person" : "More About Us"}
       </div>
       <div
-        className="h-14 bg-amber-400/12 backdrop-blur-sm border-b border-amber-300/18 text-amber-50 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
+        className="h-14 bg-white/20 backdrop-blur-md border-b border-white/40 text-amber-950 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
         onClick={() =>
           paths.includes("admin")
             ? routeNavigator("/admin/adverts")
@@ -125,7 +125,7 @@ const Navbar = () => {
         {paths.includes("admin") ? "Advertisements" : "More About Us"}
       </div>
       <div
-        className="h-14 bg-amber-300/10 backdrop-blur-sm border-b border-amber-300/15 text-amber-100 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
+        className="h-14 bg-white/20 backdrop-blur-md border-b border-white/40 text-amber-950 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
         onClick={() =>
           paths.includes("admin")
             ? routeNavigator("/admin")
@@ -135,7 +135,7 @@ const Navbar = () => {
         {paths.includes("admin") ? "Admin Account Home" : "Admin Login"}
       </div>
       <div
-        className={`bg-amber-400/10 backdrop-blur-sm border-t border-amber-300/20 w-full h-16 px-4 flex justify-between items-center hover:cursor-pointer`}
+        className={`bg-white/30 backdrop-blur-md border-t border-white/40 text-amber-950 w-full h-16 px-4 flex justify-between items-center hover:cursor-pointer`}
         onClick={toggleNavbar}
       >
         <span className="font-nunito text-2xl font-extrabold flex items-center w-full">
@@ -150,7 +150,7 @@ const Navbar = () => {
         >
           <g
             fill="none"
-            stroke="#fef3c7"
+            stroke="#451a03"
             strokeDasharray="16"
             strokeDashoffset="16"
             strokeLinecap="round"

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -42,11 +42,11 @@ const Navbar = () => {
 
   return (
     <main
-      className={`fixed md:hidden flex flex-wrap bottom-0 left-0 w-full bg-black ${height} transition-[height] border-t-2 border-black`}
+      className={`fixed md:hidden flex flex-wrap bottom-0 left-0 w-full bg-amber-950/85 backdrop-blur-xl border-t border-amber-400/30 ${height} transition-[height]`}
     >
       {height === "h-14" ? (
         <div
-          className={`bg-yellow-200 dark:bg-slate-900 w-full h-14 px-4 flex justify-between items-center hover:cursor-pointer`}
+          className={`bg-amber-400/15 backdrop-blur-sm w-full h-14 px-4 flex justify-between items-center hover:cursor-pointer`}
           onClick={toggleNavbar}
         >
           <span className="font-nunito text-2xl font-extrabold flex items-center w-full">
@@ -54,87 +54,25 @@ const Navbar = () => {
           </span>
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            className="w-10 h-10 block dark:hidden"
-            //   width="1em"
-            //   height="1em"
+            className="w-10 h-10"
             viewBox="0 0 24 24"
           >
             <g
               fill="none"
-              stroke="black"
+              stroke="#fef3c7"
               strokeDasharray="24"
               strokeDashoffset="24"
               strokeLinecap="round"
               strokeWidth="2"
             >
               <path d="M5 5H19">
-                <animate
-                  fill="freeze"
-                  attributeName="strokeDashoffset"
-                  dur="0.3s"
-                  values="24;0"
-                />
+                <animate fill="freeze" attributeName="strokeDashoffset" dur="0.3s" values="24;0" />
               </path>
               <path d="M5 12H19">
-                <animate
-                  fill="freeze"
-                  attributeName="strokeDashoffset"
-                  begin="0.2s"
-                  dur="0.3s"
-                  values="24;0"
-                />
+                <animate fill="freeze" attributeName="strokeDashoffset" begin="0.2s" dur="0.3s" values="24;0" />
               </path>
               <path d="M5 19H19">
-                <animate
-                  fill="freeze"
-                  attributeName="strokeDashoffset"
-                  begin="0.4s"
-                  dur="0.3s"
-                  values="24;0"
-                />
-              </path>
-            </g>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="w-10 h-10 hidden dark:block"
-            //   width="1em"
-            //   height="1em"
-            viewBox="0 0 24 24"
-          >
-            <g
-              fill="none"
-              stroke="white"
-              strokeDasharray="24"
-              strokeDashoffset="24"
-              strokeLinecap="round"
-              strokeWidth="2"
-            >
-              <path d="M5 5H19">
-                <animate
-                  fill="freeze"
-                  attributeName="strokeDashoffset"
-                  dur="0.3s"
-                  values="24;0"
-                />
-              </path>
-              <path d="M5 12H19">
-                <animate
-                  fill="freeze"
-                  attributeName="strokeDashoffset"
-                  begin="0.2s"
-                  dur="0.3s"
-                  values="24;0"
-                />
-              </path>
-              <path d="M5 19H19">
-                <animate
-                  fill="freeze"
-                  attributeName="strokeDashoffset"
-                  begin="0.4s"
-                  dur="0.3s"
-                  values="24;0"
-                />
+                <animate fill="freeze" attributeName="strokeDashoffset" begin="0.4s" dur="0.3s" values="24;0" />
               </path>
             </g>
           </svg>
@@ -142,14 +80,14 @@ const Navbar = () => {
       ) : null}
       {paths.includes("admin") ? (
         <div
-          className="h-14 bg-red-500 text-white w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
+          className="h-14 bg-red-500/20 backdrop-blur-sm border-b border-red-400/30 text-red-200 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
           onClick={logoutUser}
         >
           Logout
         </div>
       ) : (
         <div
-          className="h-14 bg-amber-500 dark:bg-gray-900 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
+          className="h-14 bg-amber-400/20 backdrop-blur-sm border-b border-amber-300/25 text-amber-50 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
           onClick={() => routeNavigator("/")}
         >
           <img src="/newfavicon.png" alt="logo" className="h-8 w-8 mx-2" />
@@ -157,7 +95,7 @@ const Navbar = () => {
         </div>
       )}
       <div
-        className="h-14 bg-amber-400 dark:bg-gray-800 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
+        className="h-14 bg-amber-400/15 backdrop-blur-sm border-b border-amber-300/20 text-amber-50 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
         onClick={() =>
           paths.includes("admin")
             ? routeNavigator("/admin/missing")
@@ -167,7 +105,7 @@ const Navbar = () => {
         {paths.includes("admin") ? "Add Missing Person" : "Become A Sponsor"}
       </div>
       <div
-        className="h-14 bg-amber-300 dark:bg-gray-700 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
+        className="h-14 bg-amber-400/12 backdrop-blur-sm border-b border-amber-300/18 text-amber-50 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
         onClick={() =>
           paths.includes("admin")
             ? routeNavigator("/admin/wanted")
@@ -177,7 +115,7 @@ const Navbar = () => {
         {paths.includes("admin") ? "Add Wanted Person" : "More About Us"}
       </div>
       <div
-        className="h-14 bg-amber-300 dark:bg-gray-700 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
+        className="h-14 bg-amber-400/12 backdrop-blur-sm border-b border-amber-300/18 text-amber-50 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
         onClick={() =>
           paths.includes("admin")
             ? routeNavigator("/admin/adverts")
@@ -187,7 +125,7 @@ const Navbar = () => {
         {paths.includes("admin") ? "Advertisements" : "More About Us"}
       </div>
       <div
-        className="h-14 bg-yellow-300 dark:bg-gray-600 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
+        className="h-14 bg-amber-300/10 backdrop-blur-sm border-b border-amber-300/15 text-amber-100 w-full px-4 flex items-center font-nunito text-2xl font-extrabold hover:cursor-pointer"
         onClick={() =>
           paths.includes("admin")
             ? routeNavigator("/admin")
@@ -197,7 +135,7 @@ const Navbar = () => {
         {paths.includes("admin") ? "Admin Account Home" : "Admin Login"}
       </div>
       <div
-        className={`bg-yellow-200 dark:bg-gray-500 w-full h-16 px-4 flex justify-between items-center hover:cursor-pointer border-black`}
+        className={`bg-amber-400/10 backdrop-blur-sm border-t border-amber-300/20 w-full h-16 px-4 flex justify-between items-center hover:cursor-pointer`}
         onClick={toggleNavbar}
       >
         <span className="font-nunito text-2xl font-extrabold flex items-center w-full">
@@ -212,7 +150,7 @@ const Navbar = () => {
         >
           <g
             fill="none"
-            stroke="black"
+            stroke="#fef3c7"
             strokeDasharray="16"
             strokeDashoffset="16"
             strokeLinecap="round"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -29,7 +29,7 @@ const Sidebar = () => {
   };
 
   return (
-    <div className="w-full h-full flex flex-col mx-2 py-2 px-3 rounded-3xl bg-amber-400/10 backdrop-blur-xl border border-amber-300/20 shadow-[0_4px_24px_rgba(217,119,6,0.15)]">
+    <div className="w-full h-full flex flex-col mx-2 py-2 px-3 rounded-3xl bg-white/20 backdrop-blur-xl border border-white/50 shadow-[0_8px_32px_rgba(120,72,10,0.15)]">
       <a
         href="/"
         className="flex items-center justify-center bg-inherit my-2 text-center rounded-lg w-full font-nunito font-bold text-lg"
@@ -39,25 +39,25 @@ const Sidebar = () => {
       
       <a
         href="/admin"
-        className="bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40 transition-all duration-200 active:scale-[0.98] my-2 text-center py-2 w-full font-nunito font-bold text-lg mt-2 rounded-3xl"
+        className="bg-white/30 backdrop-blur-md border border-white/50 text-amber-950 hover:bg-white/45 hover:border-white/70 shadow-sm transition-all duration-200 active:scale-[0.98] my-2 text-center py-2 w-full font-nunito font-bold text-lg mt-2 rounded-3xl"
       >
         Home
       </a>
       <a
         href="/admin/messages"
-        className="bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40 transition-all duration-200 active:scale-[0.98] px-2 my-2 text-center py-2 w-full font-nunito font-bold text-lg mt-2 rounded-3xl"
+        className="bg-white/30 backdrop-blur-md border border-white/50 text-amber-950 hover:bg-white/45 hover:border-white/70 shadow-sm transition-all duration-200 active:scale-[0.98] px-2 my-2 text-center py-2 w-full font-nunito font-bold text-lg mt-2 rounded-3xl"
       >
         Manage Messages
       </a>
       <a
         href="/admin/missing"
-        className="bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40 transition-all duration-200 active:scale-[0.98] px-2 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
+        className="bg-white/30 backdrop-blur-md border border-white/50 text-amber-950 hover:bg-white/45 hover:border-white/70 shadow-sm transition-all duration-200 active:scale-[0.98] px-2 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
       >
         Manage Missings
       </a>
       <a
         href="/admin/wanted"
-        className="bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40 transition-all duration-200 active:scale-[0.98] px-2 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
+        className="bg-white/30 backdrop-blur-md border border-white/50 text-amber-950 hover:bg-white/45 hover:border-white/70 shadow-sm transition-all duration-200 active:scale-[0.98] px-2 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
       >
         Manage Wanteds
       </a>
@@ -69,19 +69,19 @@ const Sidebar = () => {
       </a> */}
       <a
         href="/admin/adverts"
-        className="bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40 transition-all duration-200 active:scale-[0.98] px-2 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
+        className="bg-white/30 backdrop-blur-md border border-white/50 text-amber-950 hover:bg-white/45 hover:border-white/70 shadow-sm transition-all duration-200 active:scale-[0.98] px-2 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
       >
         Advertisements
       </a>
       <a
         href="/admin/notifications"
-        className="bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40 transition-all duration-200 active:scale-[0.98] px-2 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
+        className="bg-white/30 backdrop-blur-md border border-white/50 text-amber-950 hover:bg-white/45 hover:border-white/70 shadow-sm transition-all duration-200 active:scale-[0.98] px-2 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
       >
         Notifications
       </a>
       <a
         href="#"
-        className="bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40 transition-all duration-200 active:scale-[0.98] px-2 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
+        className="bg-white/30 backdrop-blur-md border border-white/50 text-amber-950 hover:bg-white/45 hover:border-white/70 shadow-sm transition-all duration-200 active:scale-[0.98] px-2 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
       >
         Annual Contributors
       </a>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -29,7 +29,7 @@ const Sidebar = () => {
   };
 
   return (
-    <div className="w-full h-full flex flex-col mx-2 py-2 px-3 rounded-3xl bg-gradient-to-b from-amber-500 via-yellow-500 to-amber-300">
+    <div className="w-full h-full flex flex-col mx-2 py-2 px-3 rounded-3xl bg-amber-400/10 backdrop-blur-xl border border-amber-300/20 shadow-[0_4px_24px_rgba(217,119,6,0.15)]">
       <a
         href="/"
         className="flex items-center justify-center bg-inherit my-2 text-center rounded-lg w-full font-nunito font-bold text-lg"
@@ -39,25 +39,25 @@ const Sidebar = () => {
       
       <a
         href="/admin"
-        className="bg-yellow-300 text-black dark:bg-yellow-600 my-2 text-center py-2 w-full font-nunito font-bold text-lg mt-2 rounded-3xl"
+        className="bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40 transition-all duration-200 active:scale-[0.98] my-2 text-center py-2 w-full font-nunito font-bold text-lg mt-2 rounded-3xl"
       >
         Home
       </a>
       <a
         href="/admin/messages"
-        className="bg-yellow-300 text-black px-2 dark:bg-yellow-600 my-2 text-center py-2 w-full font-nunito font-bold text-lg mt-2 rounded-3xl"
+        className="bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40 transition-all duration-200 active:scale-[0.98] px-2 my-2 text-center py-2 w-full font-nunito font-bold text-lg mt-2 rounded-3xl"
       >
         Manage Messages
       </a>
       <a
         href="/admin/missing"
-        className="bg-yellow-300 text-black px-2 dark:bg-yellow-600 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
+        className="bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40 transition-all duration-200 active:scale-[0.98] px-2 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
       >
         Manage Missings
       </a>
       <a
         href="/admin/wanted"
-        className="bg-yellow-300 text-black px-2 dark:bg-yellow-600 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
+        className="bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40 transition-all duration-200 active:scale-[0.98] px-2 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
       >
         Manage Wanteds
       </a>
@@ -69,19 +69,19 @@ const Sidebar = () => {
       </a> */}
       <a
         href="/admin/adverts"
-        className="bg-yellow-300 text-black px-2 dark:bg-yellow-600 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
+        className="bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40 transition-all duration-200 active:scale-[0.98] px-2 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
       >
         Advertisements
       </a>
       <a
         href="/admin/notifications"
-        className="bg-yellow-300 px-2 text-black dark:bg-yellow-600 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
+        className="bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40 transition-all duration-200 active:scale-[0.98] px-2 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
       >
         Notifications
       </a>
       <a
         href="#"
-        className="bg-yellow-300 px-2 text-black dark:bg-yellow-600 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
+        className="bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40 transition-all duration-200 active:scale-[0.98] px-2 my-2 mt-2 text-center py-2 rounded-3xl w-full font-nunito font-bold text-lg"
       >
         Annual Contributors
       </a>

--- a/src/components/WebNavbar.tsx
+++ b/src/components/WebNavbar.tsx
@@ -45,8 +45,8 @@ const WebNavbar: React.FC = () => {
     }) => {
         const baseClasses = "relative px-4 py-2.5 rounded-xl font-medium text-sm transition-all duration-200 ease-out transform active:scale-95";
         const variantClasses = {
-            primary: "bg-slate-300 hover:bg-slate-200 text-black  hover:border-white/30",
-            danger: "bg-red-600/90 backdrop-blur-sm hover:bg-red-500/90 text-white   hover:border-red-300/50"
+            primary: "bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40",
+            danger: "bg-red-500/20 backdrop-blur-sm border border-red-400/30 text-red-200 hover:bg-red-500/30 hover:border-red-300/45"
         };
 
         if (onClick) {
@@ -87,12 +87,12 @@ const WebNavbar: React.FC = () => {
     return (
         <nav className="relative">
             {/* Main Navbar */}
-            <div className="mx-4 my-1.5 rounded-3xl bg-gradient-to-r from-amber-500 via-yellow-500 to-amber-300">
+            <div className="mx-4 my-1.5 rounded-3xl bg-amber-400/10 backdrop-blur-xl border border-amber-300/25 shadow-[0_4px_24px_rgba(217,119,6,0.2)]">
                 <div className="px-6 py-4">
                     <div className="flex items-center justify-between">
                         {/* Logo */}
                         <div className="flex items-center">
-                            <div className="text-white font-bold text-xl md:text-2xl font-nunito tracking-tight">
+                            <div className="text-amber-50 font-bold text-xl md:text-2xl font-nunito tracking-tight">
                                 Crack Crime Bahamas
                             </div>
                         </div>
@@ -157,13 +157,13 @@ const WebNavbar: React.FC = () => {
                         {/* Mobile Menu Button */}
                         <button
                             onClick={toggleMobileMenu}
-                            className="md:hidden p-2 rounded-xl bg-white/10 hover:bg-white border border-slate-700 transition-all duration-200 ease-out transform active:scale-95"
+                            className="md:hidden p-2 rounded-xl bg-amber-400/15 hover:bg-amber-400/25 border border-amber-300/30 transition-all duration-200 ease-out transform active:scale-95"
                             aria-label="Toggle mobile menu"
                         >
                             <div className="w-6 h-6 flex flex-col justify-center items-center">
-                                <div className={`w-5 h-0.5 bg-slate-700 rounded-full transition-all duration-300 ${isMobileMenuOpen ? 'rotate-45 translate-y-1.5' : ''}`}></div>
-                                <div className={`w-5 h-0.5 bg-slate-700 rounded-full mt-1 transition-all duration-300 ${isMobileMenuOpen ? 'opacity-0' : ''}`}></div>
-                                <div className={`w-5 h-0.5 bg-slate-700 rounded-full mt-1 transition-all duration-300 ${isMobileMenuOpen ? '-rotate-45 -translate-y-1.5' : ''}`}></div>
+                                <div className={`w-5 h-0.5 bg-amber-100 rounded-full transition-all duration-300 ${isMobileMenuOpen ? 'rotate-45 translate-y-1.5' : ''}`}></div>
+                                <div className={`w-5 h-0.5 bg-amber-100 rounded-full mt-1 transition-all duration-300 ${isMobileMenuOpen ? 'opacity-0' : ''}`}></div>
+                                <div className={`w-5 h-0.5 bg-amber-100 rounded-full mt-1 transition-all duration-300 ${isMobileMenuOpen ? '-rotate-45 -translate-y-1.5' : ''}`}></div>
                             </div>
                         </button>
                     </div>

--- a/src/components/WebNavbar.tsx
+++ b/src/components/WebNavbar.tsx
@@ -45,8 +45,8 @@ const WebNavbar: React.FC = () => {
     }) => {
         const baseClasses = "relative px-4 py-2.5 rounded-xl font-medium text-sm transition-all duration-200 ease-out transform active:scale-95";
         const variantClasses = {
-            primary: "bg-amber-400/15 backdrop-blur-sm border border-amber-300/25 text-amber-50 hover:bg-amber-400/25 hover:border-amber-200/40",
-            danger: "bg-red-500/20 backdrop-blur-sm border border-red-400/30 text-red-200 hover:bg-red-500/30 hover:border-red-300/45"
+            primary: "bg-white/30 backdrop-blur-md border border-white/50 text-amber-950 hover:bg-white/45 hover:border-white/70 shadow-sm",
+            danger: "bg-red-500/85 backdrop-blur-md border border-red-300/50 text-white hover:bg-red-600/90 hover:border-red-200/60 shadow-sm"
         };
 
         if (onClick) {
@@ -87,12 +87,12 @@ const WebNavbar: React.FC = () => {
     return (
         <nav className="relative">
             {/* Main Navbar */}
-            <div className="mx-4 my-1.5 rounded-3xl bg-amber-400/10 backdrop-blur-xl border border-amber-300/25 shadow-[0_4px_24px_rgba(217,119,6,0.2)]">
+            <div className="mx-4 my-1.5 rounded-3xl bg-white/20 backdrop-blur-xl border border-white/50 shadow-[0_8px_32px_rgba(120,72,10,0.18)]">
                 <div className="px-6 py-4">
                     <div className="flex items-center justify-between">
                         {/* Logo */}
                         <div className="flex items-center">
-                            <div className="text-amber-50 font-bold text-xl md:text-2xl font-nunito tracking-tight">
+                            <div className="text-amber-950 font-bold text-xl md:text-2xl font-nunito tracking-tight">
                                 Crack Crime Bahamas
                             </div>
                         </div>
@@ -157,11 +157,11 @@ const WebNavbar: React.FC = () => {
                         {/* Mobile Menu Button */}
                         <button
                             onClick={toggleMobileMenu}
-                            className="md:hidden p-2 rounded-xl bg-amber-400/15 hover:bg-amber-400/25 border border-amber-300/30 transition-all duration-200 ease-out transform active:scale-95"
+                            className="md:hidden p-2 rounded-xl bg-white/30 hover:bg-white/45 border border-white/50 transition-all duration-200 ease-out transform active:scale-95"
                             aria-label="Toggle mobile menu"
                         >
                             <div className="w-6 h-6 flex flex-col justify-center items-center">
-                                <div className={`w-5 h-0.5 bg-amber-100 rounded-full transition-all duration-300 ${isMobileMenuOpen ? 'rotate-45 translate-y-1.5' : ''}`}></div>
+                                <div className={`w-5 h-0.5 bg-amber-950 rounded-full transition-all duration-300 ${isMobileMenuOpen ? 'rotate-45 translate-y-1.5' : ''}`}></div>
                                 <div className={`w-5 h-0.5 bg-amber-100 rounded-full mt-1 transition-all duration-300 ${isMobileMenuOpen ? 'opacity-0' : ''}`}></div>
                                 <div className={`w-5 h-0.5 bg-amber-100 rounded-full mt-1 transition-all duration-300 ${isMobileMenuOpen ? '-rotate-45 -translate-y-1.5' : ''}`}></div>
                             </div>
@@ -171,7 +171,7 @@ const WebNavbar: React.FC = () => {
 
                 {/* Mobile Navigation Menu */}
                 <div className={`md:hidden overflow-hidden transition-all duration-300 ease-out ${isMobileMenuOpen ? 'max-h-80 opacity-100' : 'max-h-0 opacity-0'}`}>
-                    <div className="px-6 pb-4 border-t border-white/10">
+                    <div className="px-6 pb-4 border-t border-amber-900/15">
                         {pathname.includes("admin") ? (
                             <div className="flex flex-col space-y-3 pt-4">
                                 <NavLink href="/admin">


### PR DESCRIPTION
## Summary

Applies an Apple **Liquid Glass** aesthetic across the app while keeping the existing **bright amber/golden brand identity**. The brand color shifts from opaque fills to a tint seen *through* frosted glass, rather than being replaced.

## Approach

- **Bright golden background** retained — `yellow-300 → amber-400 → amber-500` gradient. The base theme is preserved, not darkened.
- **Panels** (navbars, sidebar, cards, sections, list items, modal, footer) become **light frosted glass**: `bg-white/15–40` + `backdrop-blur` + `border-white/40–60`, so the gold glows through.
- **Text** is dark (`text-amber-950 / 900 / 800`) for high contrast on the light frost.
- **Buttons**: light frosted glass with dark text; danger/logout uses a saturated red with white text.

## Commits

- `dd1048c` — Apply Apple Liquid Glass aesthetic with amber brand tint
- `d49b2f3` — Restore bright amber base theme and fix button contrast

The second commit corrects a first pass that went too dark and had low-contrast buttons; the final result keeps the amber identity with proper contrast.

## Files touched

`globals.css`, `WebNavbar`, `Sidebar`, `Navbar` (mobile), landing `page.tsx`, admin dashboard, missing/wanted list pages, `Modal`, `Footer`.

## Verification

- Dev server compiles cleanly; `/` and `/admin` return 200.
- Verified visually in a browser preview — golden theme present, frosted-glass panels render, all buttons legible with dark text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
